### PR TITLE
Trigger Images on Base Image Updates

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,6 +39,20 @@ resources:
     username: {{docker-hub-username}}
     password: {{docker-hub-password}}
     repository: springio/spring-neo-base
+- name: openjdk:8-jdk
+  type: docker-image
+  source:
+    repository: openjdk
+    tag:        8-jdk
+- name: neo4j
+  type: docker-image
+  source:
+    repository: neo4j
+- name: rabbitmq:management
+  type: docker-image
+  source:
+    repository: rabbitmq
+    tag:        management
 - name: gs-accessing-data-gemfire
   type: git
   source:
@@ -250,14 +264,15 @@ jobs:
       trigger: true
     - get: image-source
       trigger: true
-  - aggregate:
-    - task: setup
-      file: ci/image/setup.yml
-      input_mapping:
-        source: image-source
-      params:
-        PUBLIC_KEY: {{public-key}}
-        PRIVATE_KEY: {{private-key}}
+    - get: openjdk:8-jdk
+      trigger: true
+  - task: setup
+    file: ci/image/setup.yml
+    input_mapping:
+      source: image-source
+    params:
+      PUBLIC_KEY: {{public-key}}
+      PRIVATE_KEY: {{private-key}}
   - put: base-image
     params:
       build: build/image
@@ -269,6 +284,8 @@ jobs:
     - get: ci
       trigger: true
     - get: image-source
+      trigger: true
+    - get: rabbitmq:management
       trigger: true
   - task: setup
     file: ci/image/setup.yml
@@ -289,6 +306,8 @@ jobs:
       trigger: true
     - get: image-source
       trigger: true
+    - get: openjdk:8-jdk
+      trigger: true
   - task: setup
     file: ci/image/setup.yml
     input_mapping:
@@ -308,6 +327,8 @@ jobs:
     - get: ci
       trigger: true
     - get: image-source
+      trigger: true
+    - get: neo4j
       trigger: true
   - task: setup
     file: ci/image/setup.yml


### PR DESCRIPTION
Previously, the image builds would only be triggered by changes to image- source or ci.  This left out the very common trigger of changes to the underlying base image of each of the custom Docker images.  Changes to these images typically include security updated and given that the creation of new Docker images is completely hands off, there's no reason that these security updates shouldn't be consumed as soon as they are available.  This change adds resources for each of the base images and uses them as triggering resources to the docker image jobs.